### PR TITLE
TestGocloak_GetRawUserInfo now tests client.GetRawUserInfo instead of the client.GetUserInfo

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -633,7 +633,7 @@ func TestGocloak_GetRawUserInfo(t *testing.T) {
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
-	userInfo, err := client.GetUserInfo(
+	userInfo, err := client.GetRawUserInfo(
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,


### PR DESCRIPTION
fixed, was presumably intended: 

`TestGocloak_GetRawUserInfo` now tests `client.GetRawUserInfo` instead of the `client.GetUserInfo`

Impact: small - both variants use the same endpoint, they differ only in automatic unmarshalling targets
